### PR TITLE
Fixed wrong spelling of config variable

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -12,7 +12,7 @@ Route::middleware(array_merge([
     'auth:sanctum',
     config('jetstream.auth_session'),
     'verified'],
-    config('livecontrols.route_middlewares',[]) 
+    config('livecontrols.routes_middlewares',[]) 
     )
     )->group(function(){
 


### PR DESCRIPTION
The variable routes_middlewares was spelled route_middlewares in the web router, this is fixed now