### PR TITLE
Nightly

### DIFF
--- a/src/Http/Middleware/Banning/BanCheck.php
+++ b/src/Http/Middleware/Banning/BanCheck.php
@@ -16,7 +16,7 @@ class BanCheck
      */
     public function handle(Request $request, Closure $next)
     {
-        if(config('livecontrols.banning_enabled', false)){
+        if(!config('livecontrols.banning_enabled', false)){
             return $next($request);
         }
 

--- a/src/LiveControlsServiceProvider.php
+++ b/src/LiveControlsServiceProvider.php
@@ -113,7 +113,11 @@ class LiveControlsServiceProvider extends ServiceProvider
 
       $this->publishes([
         __DIR__.'/../lang' => resource_path('lang/vendor/livecontrols'),
-      ], 'livewirecontrols-localization');
+      ], 'livecontrols-localization');
+
+      $this->publishes([
+        __DIR__.'/../resources/views' => resource_path('views/vendor/livecontrols'),
+      ], 'livecontrols-views');
     }
   }
 }

--- a/src/Models/Banning/Ban.php
+++ b/src/Models/Banning/Ban.php
@@ -20,7 +20,7 @@ class Ban extends Model{
     ];
 
     protected $casts = [
-        'banned_until' => 'dateTime'
+        'banned_until' => 'datetime'
     ];
 
     public function users():BelongsToMany

--- a/src/Traits/Banning/HasBanning.php
+++ b/src/Traits/Banning/HasBanning.php
@@ -21,13 +21,16 @@ trait HasBanning
                 if(!is_null($this->ban->banned_until)){
                     if($this->ban->banned_until->isFuture()){
                         return true;
+                    }else{
+                        $this->ban()->delete();
+                        return false;
                     }
                 }else{
                     return true;
                 }
             }
         }   
-        false;
+        return false;
     }
 
     public function doBan(Carbon $banned_until = null): bool

--- a/src/Traits/Banning/HasBanning.php
+++ b/src/Traits/Banning/HasBanning.php
@@ -34,4 +34,9 @@ trait HasBanning
     {
         return $this->ban()->delete();
     }
+
+    public function bannedUntil(): Carbon|null
+    {
+        return is_null($this->ban) ? null : $this->ban->banned_until;
+    }
 }

--- a/src/Traits/Banning/HasBanning.php
+++ b/src/Traits/Banning/HasBanning.php
@@ -16,7 +16,16 @@ trait HasBanning
     public function isBanned(): bool
     {
         if(config('livecontrols.banning_enabled', false)){
-            return !is_null($this->ban);
+            if(!is_null($this->ban)){
+                //Check if banned_until is not null
+                if(!is_null($this->ban->banned_until)){
+                    if($this->ban->banned_until->isFuture()){
+                        return true;
+                    }
+                }else{
+                    return true;
+                }
+            }
         }   
         false;
     }

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -85,6 +85,14 @@ class Utils
         return $numero_extenso;
     }
 
+    /**
+     * Adds leading zeros to a integer value like ID etc.
+     *
+     * @param integer $value The integer value you want to edit
+     * @param integer $length The length of the returned string (missing numbers will be replaced with leading zeros)
+     * @param boolean $isMax IF set to true, length will be the max length and an exception will be thrown if number is bigger
+     * @return string
+     */
     public static function leadingZeros(int $value, int $length, bool $isMax = false):string
     {
         $value = strval($value);


### PR DESCRIPTION
# Additions
- Added bannedUntil() to HasBanning trait to return a Carbon date or null
- Added exportable views, they can be exported with the livecontrols-views tag

# Changes
- Ban will be removed if banned_until is not null and if banned_until is in the past.
- Added documentation to leadingZeros() method in Utils class

# Fixes
- Fixed wrong check if banning is enabled in Middleware
- Fixed isBanned() method in HasBanning trait. It didn't take "banned_until" in account before.
- Fixed tag of localization export (was livewire-controls before, changed it to live-controls)
- Fixed wrong spelling of datetime in Ban Model