### PR TITLE
Added function to manually add items to imagegallery

### DIFF
--- a/src/Http/Livewire/Images/ImageGallery.php
+++ b/src/Http/Livewire/Images/ImageGallery.php
@@ -17,6 +17,11 @@ class ImageGallery extends Component
 
     public function mount()
     {
+        if(is_array($this->items) && count($this->items) > 0 && array_key_exists('name', $this->items[0]) && array_key_exists('items', $this->items[0])){
+            //Do not load any models, if items are set manually
+            return;
+        }
+
         $fetchedColumns = [$this->idColumn];
         if($this->titleColumn != null){
             array_push($fetchedColumns, $this->titleColumn);


### PR DESCRIPTION
# Changes
- Added function to manually add image items to ImageGallery, you should add an array like this to the $items variable:
```php
$items => [
     'modelname' => [
          'name' => 'modelname,
          'items' => [
               'id' => 1,
               'title' => 'An Image',
               'columns' => [
                     'column1' => [
                          'path' => '/path/to/file',
                          'url' => '/url/to/file'
                     ]
                ]
          ]
     ]
]
```